### PR TITLE
休日関連のイベント処理変更

### DIFF
--- a/DesktopClock/CalendarWindow.xaml
+++ b/DesktopClock/CalendarWindow.xaml
@@ -60,7 +60,7 @@
     </Window.Resources>
     <StackPanel>
         <TextBlock Height="31"/>
-        <Grid Background="#77111111">
+        <Grid Background="#99111111">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />

--- a/DesktopClock/MainWindow.xaml.cs
+++ b/DesktopClock/MainWindow.xaml.cs
@@ -32,7 +32,6 @@ namespace DesktopClock
                 }
             };
 
-            // ここマジアブナイ。
             viewModel = new MainWindowViewModel
             {
                 DateTimeEventSource = dtEvtSrc,

--- a/DesktopClock/MainWindowViewModel.cs
+++ b/DesktopClock/MainWindowViewModel.cs
@@ -708,14 +708,14 @@ namespace DesktopClock
 
             public bool CanExecute(object parameter)
             {
-                var today = viewModel.DateTimeEventSource.Today;
+                var today = DateTime.Today;
                 return today.Year != Int32.Parse(viewModel.CalendarYear)
                         || today.Month != Int32.Parse(viewModel.CalendarMonth);
             }
 
             public void Execute(object parameter)
             {
-                var timestamp = viewModel.DateTimeEventSource.Now;
+                var timestamp = DateTime.Now;
                 viewModel.CalendarYear = timestamp.Year.ToString();
                 viewModel.CalendarMonth =timestamp.Month.ToString();
             }
@@ -1128,7 +1128,7 @@ namespace DesktopClock
         /// </summary>
         private void InitializeCalender()
         {
-            var timestamp = DateTimeEventSource.Now;
+            var timestamp = DateTime.Now;
             CalendarYear = timestamp.Year.ToString();
             CalendarMonth = timestamp.Month.ToString();
 

--- a/DesktopClock/MainWindowViewModel.cs
+++ b/DesktopClock/MainWindowViewModel.cs
@@ -1128,7 +1128,7 @@ namespace DesktopClock
         /// </summary>
         private void InitializeCalender()
         {
-            var timestamp = DateTimeEventSource.Now;
+            var timestamp = DateTime.Now; // DateTimeEventSource 設定前に実施するため。
             CalendarYear = timestamp.Year.ToString();
             CalendarMonth = timestamp.Month.ToString();
 

--- a/DesktopClock/MainWindowViewModel.cs
+++ b/DesktopClock/MainWindowViewModel.cs
@@ -1128,7 +1128,7 @@ namespace DesktopClock
         /// </summary>
         private void InitializeCalender()
         {
-            var timestamp = DateTime.Now; // DateTimeEventSource 設定前に実施するため。
+            var timestamp = DateTimeEventSource.Now;
             CalendarYear = timestamp.Year.ToString();
             CalendarMonth = timestamp.Month.ToString();
 

--- a/DesktopClock/MainWindowViewModel.cs
+++ b/DesktopClock/MainWindowViewModel.cs
@@ -708,14 +708,14 @@ namespace DesktopClock
 
             public bool CanExecute(object parameter)
             {
-                var today = DateTime.Today;
+                var today = viewModel.DateTimeEventSource.Today;
                 return today.Year != Int32.Parse(viewModel.CalendarYear)
                         || today.Month != Int32.Parse(viewModel.CalendarMonth);
             }
 
             public void Execute(object parameter)
             {
-                var timestamp = DateTime.Now;
+                var timestamp = viewModel.DateTimeEventSource.Now;
                 viewModel.CalendarYear = timestamp.Year.ToString();
                 viewModel.CalendarMonth =timestamp.Month.ToString();
             }
@@ -1128,7 +1128,7 @@ namespace DesktopClock
         /// </summary>
         private void InitializeCalender()
         {
-            var timestamp = DateTime.Now;
+            var timestamp = DateTimeEventSource.Now;
             CalendarYear = timestamp.Year.ToString();
             CalendarMonth = timestamp.Month.ToString();
 

--- a/DesktopClockLibrary/CustomHoliday.cs
+++ b/DesktopClockLibrary/CustomHoliday.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Collections.Specialized;
 
 namespace DesktopClock.Library
 {
@@ -25,8 +23,16 @@ namespace DesktopClock.Library
                 if (_Holidays != null) throw new InvalidOperationException("already setted.");
 
                 _Holidays = value;
+                HolidaySettingChanged?.Invoke(this, new NotifyHolidaySettingChangedEventArgs(nameof(Holidays)));
+
+                _Holidays.CollectionChanged += (object sender ,NotifyCollectionChangedEventArgs e) =>
+                {
+                    HolidaySettingChanged?.Invoke(sender, new NotifyHolidaySettingChangedEventArgs(nameof(Holidays), e));
+                };
             }
         }
+
+        public event HolidaySettingChangedEventHandler HolidaySettingChanged;
 
         /// <summary>
         /// 年月日に対応するカスタム休日の名前を取得します。

--- a/DesktopClockLibrary/DateTimeEventSource.cs
+++ b/DesktopClockLibrary/DateTimeEventSource.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.ComponentModel;
@@ -206,6 +203,11 @@ namespace DesktopClock.Library
             set {
                 if (_HolidayChecker != null) throw new InvalidOperationException("already setted.");
                 _HolidayChecker = value;
+                _HolidayChecker.HolidaySettingChanged += (object sender, NotifyHolidaySettingChangedEventArgs e) =>
+                {
+                    HolidaySettingChanged?.Invoke(sender, e);
+                };
+
             }
         }
 
@@ -225,9 +227,14 @@ namespace DesktopClock.Library
         }
 
         /// <summary>
-        /// プロパティが変更されたときに発生するイベント。
+        /// このオブジェクトのプロパティが変更されたときに発生するイベント。
         /// </summary>
         public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// <see cref="INotifyHolidaySettingChanged.HolidaySettingChanged" /> のイベントを転送します。
+        /// </summary>
+        public event HolidaySettingChangedEventHandler HolidaySettingChanged;
 
         private CancellationTokenSource tokenSource;
         

--- a/DesktopClockLibrary/HolidayChecker.cs
+++ b/DesktopClockLibrary/HolidayChecker.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DesktopClock.Library
 {
@@ -17,14 +13,23 @@ namespace DesktopClock.Library
         private static readonly DateTime KokuminNoKyuujitsuStart = new DateTime(1985, 12, 27);
         private static readonly DateTime FurikaeKyuujitsuChangeAt2007 = new DateTime(2007, 1, 1);
 
+        private bool _IsAddHolidayNameToObservedHolidayName;
         /// <summary>
         /// 振替休日に元の祝祭日名を含めるか。true の場合は <see cref="GetHolidayName(DateTime)" /> や <see cref="GetHolidayName(int, int, int)" /> が振替休日を「振替休日 (元の祝祭日名)」と、false の場合は単に「振替休日」と返すようになります。
         /// </summary>
-        public bool IsAddHolidayNameToObservedHolidayName { get; set; }
+        public bool IsAddHolidayNameToObservedHolidayName
+        {
+            get { return _IsAddHolidayNameToObservedHolidayName; }
+            set
+            {
+                _IsAddHolidayNameToObservedHolidayName = value;
+                HolidaySettingChanged?.Invoke(this, new NotifyHolidaySettingChangedEventArgs(nameof(IsAddHolidayNameToObservedHolidayName)));
+            }
+        }
 
         private ICustomHoliday _CustomHoliday;
         /// <summary>
-        /// 
+        /// <see cref="ICustomHoliday" /> をセットします。
         /// </summary>
         public ICustomHoliday CustomHoliday
         {
@@ -36,8 +41,15 @@ namespace DesktopClock.Library
             {
                 if (_CustomHoliday != null) throw new InvalidOperationException("already setted.");
                 _CustomHoliday = value;
+                HolidaySettingChanged?.Invoke(this, new NotifyHolidaySettingChangedEventArgs(nameof(CustomHoliday)));
+                _CustomHoliday.HolidaySettingChanged += (object sender, NotifyHolidaySettingChangedEventArgs e) =>
+                {
+                    HolidaySettingChanged?.Invoke(sender, e);
+                };
             }
         }
+
+        public event HolidaySettingChangedEventHandler HolidaySettingChanged;
 
         /// <summary>
         /// 祝祭日名を取得します。

--- a/DesktopClockLibrary/HolidaySettingChangedEventArgs.cs
+++ b/DesktopClockLibrary/HolidaySettingChangedEventArgs.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace DesktopClock.Library
+{
+    public class NotifyHolidaySettingChangedEventArgs : EventArgs
+    {
+        public string PropertyName { get; private set; }
+        public EventArgs OriginalEventArgs { get; private set; }
+        public NotifyHolidaySettingChangedEventArgs(string propertyName, EventArgs originalEventArgs = null)
+        {
+            PropertyName = propertyName;
+            OriginalEventArgs = originalEventArgs;
+        }
+    }
+}

--- a/DesktopClockLibrary/ICustomHoliday.cs
+++ b/DesktopClockLibrary/ICustomHoliday.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace DesktopClock.Library
 {

--- a/DesktopClockLibrary/ICustomHoliday.cs
+++ b/DesktopClockLibrary/ICustomHoliday.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -10,7 +11,7 @@ namespace DesktopClock.Library
      /// <summary>
      /// カスタム休日。
      /// </summary>
-    public interface ICustomHoliday
+    public interface ICustomHoliday : INotifyHolidaySettingChanged
     {
         /// <summary>
         /// カスタム休日の一覧。変更イベントを外部で処理できるよう <see cref="System.Collections.ObjectModel.ObservableCollection{T}"/> です。

--- a/DesktopClockLibrary/ICustomHoliday.cs
+++ b/DesktopClockLibrary/ICustomHoliday.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DesktopClock.Library
 {

--- a/DesktopClockLibrary/IDateTimeEventSource.cs
+++ b/DesktopClockLibrary/IDateTimeEventSource.cs
@@ -1,9 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using System.ComponentModel;
 
 namespace DesktopClock.Library
@@ -11,7 +6,7 @@ namespace DesktopClock.Library
     /// <summary>
     /// 時刻が変わった際に各プロパティに対応した <see cref="INotifyPropertyChanged.PropertyChanged" /> イベントを発生させます。
     /// </summary>
-    public interface IDateTimeEventSource : INotifyPropertyChanged
+    public interface IDateTimeEventSource : INotifyPropertyChanged, INotifyHolidaySettingChanged
     {
         /// <summary>
         /// 年。
@@ -71,6 +66,7 @@ namespace DesktopClock.Library
 
         /// <summary>
         /// 祝祭日かを判断するための <see cref="IHolidayChecker" />。
+        /// このプロパティに HolidayChecker をセットすると、<see cref="IHolidayChecker.CollectionChanged" /> イベントを転送するようになります。
         /// </summary>
         public IHolidayChecker HolidayChecker { get; set; }
 

--- a/DesktopClockLibrary/IHolidayChecker.cs
+++ b/DesktopClockLibrary/IHolidayChecker.cs
@@ -1,15 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DesktopClock.Library
 {
     /// <summary>
     /// ある日付に対応する祝祭日名を返すための処理を担います。
     /// </summary>
-    public interface IHolidayChecker
+    public interface IHolidayChecker : INotifyHolidaySettingChanged
     {
         /// <summary>
         /// 振替休日に元の祝祭日名を含めるか。true の場合は <see cref="GetHolidayName(DateTime)" /> や <see cref="GetHolidayName(int, int, int)" /> が振替休日を「振替休日 (元の祝祭日名)」と、false の場合は単に「振替休日」と返すようになります。

--- a/DesktopClockLibrary/INotifyHolidaySettingChanged.cs
+++ b/DesktopClockLibrary/INotifyHolidaySettingChanged.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace DesktopClock.Library
+{
+    public interface INotifyHolidaySettingChanged
+    {
+        public event HolidaySettingChangedEventHandler HolidaySettingChanged;
+    }
+
+    public delegate void HolidaySettingChangedEventHandler(object sender, NotifyHolidaySettingChangedEventArgs e);
+}


### PR DESCRIPTION
休日のイベント ハンドラーを設定する際、休日関連のオブジェクト直で設定すると、初期化や設定変更の順序などに色々縛りが出るため、IDateTimeEventSource 経由で受け取れるように変更した。