### PR TITLE
カレンダーのボタン サイズ調整

### DIFF
--- a/DesktopClock/CalendarWindow.xaml
+++ b/DesktopClock/CalendarWindow.xaml
@@ -94,7 +94,7 @@
                     Command="{Binding PreviousMonthCommand}"
                     Style="{StaticResource CalendarButton}"
                     VerticalAlignment="Stretch"  HorizontalAlignment="Stretch"  
-                    Padding="6" Grid.Row="1" Grid.Column="1" />
+                    Padding="4" Grid.Row="1" Grid.Column="1" />
             <Grid HorizontalAlignment="Center" Grid.Row="1" Grid.Column="2">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="33"/>
@@ -168,7 +168,7 @@
                     Command="{Binding NextMonthCommand}"
                     Style="{StaticResource CalendarButton}"
                     VerticalAlignment="Stretch"  HorizontalAlignment="Stretch"  
-                    Padding="6" Grid.Row="1" Grid.Column="3" />
+                    Padding="4" Grid.Row="1" Grid.Column="3" />
         </Grid>
     </StackPanel>
 </Window>


### PR DESCRIPTION
左右のボタン サイズにズレが発生していたため、サイズを変更。