### PR TITLE
カレンダーの不要な初期化の削除

### DIFF
--- a/DesktopClock/MainWindow.xaml.cs
+++ b/DesktopClock/MainWindow.xaml.cs
@@ -32,7 +32,7 @@ namespace DesktopClock
                 }
             };
 
-            viewModel = new MainWindowViewModel
+            viewModel = new MainWindowViewModel(this.Dispatcher)
             {
                 DateTimeEventSource = dtEvtSrc,
                 PrimaryScreenSizeEventSource = new PrimaryScreenSizeEventSource()


### PR DESCRIPTION
カレンダーの不要な初期化を削除した。併せて、日付変更時に表示年月を変更するようにした。
但し、原因は不明だが Dispatcher 経由でないとプロパティにセットできなかった。タイミングの問題であれば、他のセットも潜在的にバグ持ちかもしれない。