### PR TITLE
カレンダーの本日表示バグ修正

### DIFF
--- a/DesktopClockLibrary/MainWindowViewModel.cs
+++ b/DesktopClockLibrary/MainWindowViewModel.cs
@@ -1575,6 +1575,7 @@ namespace DesktopClock.Library
                     else
                     {
                         _CalendarNumbers[i, j] = String.Empty;
+                        _CalendarBackgrounds[i, j] = System.Windows.Media.Brushes.Transparent;
                     }
                 }
             }


### PR DESCRIPTION
先月および翌月に切り替えた際、当月の今日の位置が空白部分に当てはまる時、背景色がリセットされない件の修正。